### PR TITLE
Simplify distributed training env vars

### DIFF
--- a/website/docs/cheatsheet/distributed-training.md
+++ b/website/docs/cheatsheet/distributed-training.md
@@ -136,9 +136,6 @@ def set_environment_variables_for_nccl_backend(master_port=6105, verbose=True):
         print("WORLD_SIZE = {}".format(os.environ["WORLD_SIZE"]))
         print("MASTER_ADDR = {}".format(os.environ["MASTER_ADDR"]))
         print("MASTER_PORT = {}".format(os.environ["MASTER_PORT"]))
-        print(
-            "NCCL_SOCKET_IFNAME new value = {}".format(os.environ["NCCL_SOCKET_IFNAME"])
-        )
 
 def get_rank():
     return int(os.environ["OMPI_COMM_WORLD_RANK"])

--- a/website/docs/cheatsheet/distributed-training.md
+++ b/website/docs/cheatsheet/distributed-training.md
@@ -130,12 +130,7 @@ def set_environment_variables_for_nccl_backend(master_port=6105, verbose=True):
     else:
         os.environ["MASTER_ADDR"] = os.environ["AZ_BATCHAI_MPI_MASTER_NODE"]
         os.environ["MASTER_PORT"] = "54965"
-    print(
-        "NCCL_SOCKET_IFNAME original value = {}".format(
-            os.environ["NCCL_SOCKET_IFNAME"]
-        )
-    )
-    os.environ["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
+
     if verbose:
         print("RANK = {}".format(os.environ["RANK"]))
         print("WORLD_SIZE = {}".format(os.environ["WORLD_SIZE"]))

--- a/website/docs/cheatsheet/distributed-training.md
+++ b/website/docs/cheatsheet/distributed-training.md
@@ -495,7 +495,6 @@ else:
     os.environ["MASTER_ADDR"] = os.environ["AZ_BATCHAI_MPI_MASTER_NODE"]
     os.environ["MASTER_PORT"] = "54965"
 
-os.environ["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
 os.environ["NODE_RANK"] = os.environ["OMPI_COMM_WORLD_RANK"] 
 ```
 
@@ -507,6 +506,9 @@ trainer: Trainer = pl.Trainer.from_argparse_args(
 
 trainer.fit(model, train_loader, val_loader)
 ```
+
+**Example.** Here is an example of mutlti-node distributed training using PyTorch Lightning
+from the [azureml-examples repo](https://github.com/Azure/azureml-examples/blob/main/tutorials/using-pytorch-lightning/4.train-multi-node-ddp.ipynb).
 
 ## TensorFlow
 


### PR DESCRIPTION
- Simplify the `set_environment_variables_for_nccl_backend` method
- Add example from azureml-examples repo using pytorch lightning multinode distributed training